### PR TITLE
[nrf fromlist] cmake: kconfig: zephyr multi image built support

### DIFF
--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -167,6 +167,14 @@ if(NOT CONFIG_BOOT_SIGNATURE_KEY_FILE STREQUAL "")
   else()
     set(KEY_FILE ${MCUBOOT_DIR}/${CONFIG_BOOT_SIGNATURE_KEY_FILE})
   endif()
+
+  set_property(
+	GLOBAL
+	PROPERTY
+	KEY_FILE
+	${KEY_FILE}
+	)
+
   set(GENERATED_PUBKEY ${ZEPHYR_BINARY_DIR}/autogen-pubkey.c)
   add_custom_command(
     OUTPUT ${GENERATED_PUBKEY}
@@ -182,3 +190,12 @@ if(NOT CONFIG_BOOT_SIGNATURE_KEY_FILE STREQUAL "")
   zephyr_library_sources(${GENERATED_PUBKEY})
 endif()
 
+# TODO: Configurable?
+set_property(GLOBAL APPEND PROPERTY
+  HEX_FILES_TO_MERGE
+  ${PROJECT_BINARY_DIR}/zephyr/${KERNEL_HEX_NAME}
+  )
+set_property(GLOBAL APPEND PROPERTY
+  HEX_FILES_TO_MERGE_TARGET
+  ${logical_target_for_zephyr_elf}
+  )

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -91,14 +91,6 @@ endchoice
 endif
 endchoice
 
-config BOOT_SIGNATURE_KEY_FILE
-	string "PEM key file"
-	default ""
-	help
-	  The key file will be parsed by imgtool's getpub command and a .c source
-	  with the public key information will be written in a format expected by
-	  MCUboot.
-
 config MBEDTLS_CFG_FILE
 	default "mcuboot-mbedtls-cfg.h"
 

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -1,0 +1,39 @@
+if(CONFIG_BOOTLOADER_MCUBOOT)
+  # Build a second bootloader image
+
+  set(MCUBOOT_BASE ${CMAKE_CURRENT_LIST_DIR}/..)
+
+  zephyr_add_executable(mcuboot require_build)
+
+  if (${require_build})
+    add_subdirectory(${MCUBOOT_BASE}/boot/zephyr ${CMAKE_CURRENT_BINARY_DIR}/mcuboot)
+
+    # TODO: Assert that the bootloader and image use the same key.
+
+    set(SIGNED_IMAGE signed.hex)
+
+    set_property(GLOBAL APPEND PROPERTY
+      extra_post_build_commands
+      COMMAND
+      ${PYTHON_EXECUTABLE}
+      ${MCUBOOT_BASE}/scripts/imgtool.py
+      sign
+      --key ${MCUBOOT_BASE}/${CONFIG_BOOT_SIGNATURE_KEY_FILE}
+      --header-size ${CONFIG_TEXT_SECTION_OFFSET}
+      --align       ${DT_FLASH_WRITE_BLOCK_SIZE}
+      --version 0.1       # TODO: Configurable?
+      --slot-size 0x32000 # TODO: Configurable?
+      ${KERNEL_HEX_NAME}  # TODO: Enforce that this will be present through Kconfig
+      ${SIGNED_IMAGE}
+      )
+
+    set_property(GLOBAL APPEND PROPERTY
+      HEX_FILES_TO_MERGE
+      ${SIGNED_IMAGE}
+      )
+    set_property(GLOBAL APPEND PROPERTY
+      HEX_FILES_TO_MERGE_TARGET
+      ${logical_target_for_zephyr_elf}
+      )
+  endif() # ${require_build}
+endif()

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -1,0 +1,46 @@
+menu "MCUboot"
+
+if BOOTLOADER_MCUBOOT
+
+config MCUBOOT_CMAKELISTS_DIR
+	string "Path to the directory of the MCUBoot CMakeLists.txt file"
+	default "$MCUBOOT_BASE/boot/zephyr/"
+
+
+choice
+	prompt "MCUBoot build strategy"
+	default MCUBOOT_BUILD_STRATEGY_FROM_SOURCE
+
+config MCUBOOT_BUILD_STRATEGY_USE_HEX_FILE
+	# Mandatory option when being built through 'zephyr_add_executable'
+	bool "Use hex file instead of building MCUBoot"
+
+if MCUBOOT_BUILD_STRATEGY_USE_HEX_FILE
+
+config MCUBOOT_HEX_FILE
+	# Mandatory option when being built through 'zephyr_add_executable'
+	string "MCUBoot hex file"
+
+endif # MCUBOOT_USE_HEX_FILE
+
+config MCUBOOT_BUILD_STRATEGY_SKIP_BUILD
+	# Mandatory option when being built through 'zephyr_add_executable'
+	bool "Skip building MCUBoot"
+
+config MCUBOOT_BUILD_STRATEGY_FROM_SOURCE
+	# Mandatory option when being built through 'zephyr_add_executable'
+	bool "Build from source"
+
+endchoice
+
+endif # BOOTLOADER_MCUBOOT
+
+config BOOT_SIGNATURE_KEY_FILE
+	string "PEM key file"
+	default "root-rsa-2048.pem"
+	help
+	  The key file will be parsed by imgtool's getpub command and a .c source
+	  with the public key information will be written in a format expected by
+	  MCUboot.
+
+endmenu


### PR DESCRIPTION
dump

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>