### PR TITLE
DNM [nrf mergeup] merge upstream up to commit 288682c

### DIFF
--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -16,14 +16,18 @@ set(BOARD qemu_x86)
 # the list).
 if(DTC_OVERLAY_FILE)
   set(DTC_OVERLAY_FILE
-      "${DTC_OVERLAY_FILE} ${CMAKE_CURRENT_LIST_DIR}/dts.overlay")
+    "${DTC_OVERLAY_FILE} ${CMAKE_CURRENT_LIST_DIR}/dts.overlay"
+    CACHE STRING "" FORCE
+    )
 else()
   set(DTC_OVERLAY_FILE ${CMAKE_CURRENT_LIST_DIR}/dts.overlay)
 endif()
 
 if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/boards/${BOARD}.overlay)
   set(DTC_OVERLAY_FILE
-      "${DTC_OVERLAY_FILE} ${CMAKE_CURRENT_LIST_DIR}/boards/${BOARD}.overlay")
+    "${DTC_OVERLAY_FILE} ${CMAKE_CURRENT_LIST_DIR}/boards/${BOARD}.overlay"
+    CACHE STRING "" FORCE
+    )
 endif()
 
 # Enable Zephyr runner options which request mass erase if so

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -14,18 +14,6 @@ config MCUBOOT
 	select MPU_ALLOW_FLASH_WRITE if ARM_MPU
 	select USE_CODE_PARTITION if HAS_FLASH_LOAD_OFFSET
 
-if BOARD_HAS_NRF5_BOOTLOADER
-
-# When compiling MCUBoot, the image will be linked to the boot partition.
-# Override .text offset to make sure it is set to zero.
-# This is necessary when other bootloaders set a different default for
-# application images which are not bootloaders.
-
-config TEXT_SECTION_OFFSET
-	default 0x00
-
-endif # BOARD_HAS_NRF5_BOOTLOADER
-
 config BOOT_USE_MBEDTLS
 	bool
 	# Hidden option

--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -156,9 +156,9 @@ def sign(key, align, version, header_size, pad_header, slot_size, pad,
     enckey = load_key(encrypt) if encrypt else None
     if enckey:
         if not isinstance(enckey, (keys.RSA2048, keys.RSA2048Public)):
-            raise Exception("Encryption only available with RSA")
-        if key and not isinstance(key, (keys.RSA2048, keys.RSA2048Public)):
-            raise Exception("Encryption with sign only available with RSA")
+            raise Exception("Encryption only available with RSA key")
+        if key and not isinstance(key, keys.RSA2048):
+            raise Exception("Signing only available with private RSA key")
     img.create(key, enckey)
     img.save(outfile)
 


### PR DESCRIPTION
* do not override TEXT_SECTION_OFFSET (The nrf52840_pca10059 board no longer
overrides TEXT_SECTION_OFFSET but sets the correct FLASH_LOAD_OFFSET
instead)
* Fix bug https://github.com/JuulLabs-OSS/mcuboot/issues/399 where dts.overlay was not being appended.
* imgtool disallow using public RSA key for signing.