### PR TITLE
zephyr: cmake: Fix for too long file paths in zephyr

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -6,7 +6,7 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
   zephyr_add_executable(mcuboot require_build)
 
   if (${require_build})
-    add_subdirectory(${MCUBOOT_BASE}/boot/zephyr ${CMAKE_CURRENT_BINARY_DIR}/mcuboot)
+    add_subdirectory(${MCUBOOT_BASE}/boot/zephyr ${CMAKE_BINARY_DIR}/mcuboot)
 
     # TODO: Assert that the bootloader and image use the same key.
 


### PR DESCRIPTION
This reduces the lengths of the filepath created for the build directory
so that it won't exceed 259 characters on windows. This also aligns with
the changes introduced with https://github.com/NordicPlayground/fw-nrfconnect-nrf/pull/647

Signed-off-by: Sigvart Hovland <sigvart.m@gmail.com>