### PR TITLE
[nrf fromlist] cmake: Fix TINYCBOR in a multi-image context

### DIFF
--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -164,7 +164,7 @@ if(CONFIG_MCUBOOT_SERIAL)
 
   zephyr_link_libraries_ifdef(
 	CONFIG_TINYCBOR
-	TINYCBOR
+	${IMAGE}TINYCBOR
 	)
 
   zephyr_include_directories_ifdef(


### PR DESCRIPTION
Fix the TINYCBOR build scripts to work with multi-image.

This patch comes from https://github.com/JuulLabs-OSS/mcuboot/pull/430/files

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>