### PR TITLE
[nrf noup] ci: limit build agent selection

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
   agent {
     docker {
       image "$IMAGE_TAG"
-      label "docker && ncs"
+      label "docker && build-node && ncs"
     }
   }
   options {


### PR DESCRIPTION
Only build agent should be used for building jobs.

Signed-off-by: Chris Bittner <chris.bittner@nordicsemi.no>