### PR TITLE
[nrf fromlist] cmake: image-ify DTC_OVERLAY_FILE

### DIFF
--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -18,18 +18,18 @@ endif()
 # and fits inside, the boot partition. (If the user specified a
 # DTC_OVERLAY_FILE on the CMake command line, we need to append onto
 # the list).
-if(DTC_OVERLAY_FILE)
-  set(DTC_OVERLAY_FILE
-    "${DTC_OVERLAY_FILE} ${CMAKE_CURRENT_LIST_DIR}/dts.overlay"
+if(${IMAGE}DTC_OVERLAY_FILE)
+  set(${IMAGE}DTC_OVERLAY_FILE
+    "${${IMAGE}DTC_OVERLAY_FILE} ${CMAKE_CURRENT_LIST_DIR}/dts.overlay"
     CACHE STRING "" FORCE
     )
 else()
-  set(DTC_OVERLAY_FILE ${CMAKE_CURRENT_LIST_DIR}/dts.overlay)
+  set(${IMAGE}DTC_OVERLAY_FILE ${CMAKE_CURRENT_LIST_DIR}/dts.overlay)
 endif()
 
 if (EXISTS ${CMAKE_CURRENT_LIST_DIR}/boards/${BOARD}.overlay)
-  set(DTC_OVERLAY_FILE
-    "${DTC_OVERLAY_FILE} ${CMAKE_CURRENT_LIST_DIR}/boards/${BOARD}.overlay"
+  set(${IMAGE}DTC_OVERLAY_FILE
+    "${${IMAGE}DTC_OVERLAY_FILE} ${CMAKE_CURRENT_LIST_DIR}/boards/${BOARD}.overlay"
     CACHE STRING "" FORCE
     )
 endif()


### PR DESCRIPTION
Contained in upstream pr https://github.com/JuulLabs-OSS/mcuboot/pull/430
This variable is per image, treat it is such.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>