### PR TITLE
[nrf toup] boot: zephyr: Update USB CDC ACM device name

### DIFF
--- a/boot/zephyr/serial_adapter.c
+++ b/boot/zephyr/serial_adapter.c
@@ -193,7 +193,7 @@ boot_uart_fifo_init(void)
 #ifdef CONFIG_BOOT_SERIAL_UART
 	uart_dev = device_get_binding(DT_UART_CONSOLE_ON_DEV_NAME);
 #elif CONFIG_BOOT_SERIAL_CDC_ACM
-	uart_dev = device_get_binding(CONFIG_CDC_ACM_PORT_NAME_0);
+	uart_dev = device_get_binding(CONFIG_USB_CDC_ACM_DEVICE_NAME "_0");
 #endif
 	u8_t c;
 


### PR DESCRIPTION
Follow the device name changes in Zephyr.

Signed-off-by: Filip Kubicz <filip.kubicz@nordicsemi.no>