### PR TITLE
kconfig: add config for mcuboot version

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -37,8 +37,8 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
     --key ${MCUBOOT_BASE}/${CONFIG_BOOT_SIGNATURE_KEY_FILE}
     --header-size $<TARGET_PROPERTY:partition_manager,MCUBOOT_HEADER_SIZE>
     --align       ${DT_FLASH_WRITE_BLOCK_SIZE}
-    --version 0.1 # TODO configurable?
-    --slot-size $<TARGET_PROPERTY:partition_manager,MCUBOOT_SLOT_SIZE>
+    --version     ${CONFIG_MCUBOOT_IMAGE_VERSION}
+    --slot-size   $<TARGET_PROPERTY:partition_manager,MCUBOOT_SLOT_SIZE>
     --pad-header
     )
 

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -33,6 +33,16 @@ config MCUBOOT_BUILD_STRATEGY_FROM_SOURCE
 
 endchoice
 
+config MCUBOOT_IMAGE_VERSION
+        string "Image version"
+        default "0.0.0+0"
+	help
+	  Value to be passed as 'version' argument to 'imgtool.py' when
+	  creating signed image. Note that no semantics are connected to
+	  this variable. It does not provide downgrade prevention, and is only
+	  valuable for debugging purposes. Format: maj.min.rev+build with
+	  latter parts optional.
+
 endif # BOOTLOADER_MCUBOOT
 
 config BOOT_SIGNATURE_KEY_FILE


### PR DESCRIPTION
Make it easier for the user to change the mcuboot version
by extracting this as a kconfig variabl.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>