### PR TITLE
kconfig: use template for partition manager config

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -14,36 +14,21 @@ config MCUBOOT
 	select MPU_ALLOW_FLASH_WRITE if ARM_MPU
 	select USE_CODE_PARTITION if HAS_FLASH_LOAD_OFFSET
 
-# Define used by partition_manager.py to deduce size of partition
-config PM_PARTITION_SIZE_MCUBOOT
-	hex "Flash space reserved for bootloader."
-	default 0xc000
-	help
-	  Flash space set aside for the MCUBoot. Note, the name
-	  of this configuration needs to match the requirements set by the
-	  script 'partition_manager.py'. See pm.yaml.
+partition=MCUBOOT
+partition-size=0xc000
+source "${ZEPHYR_BASE}/../nrf/subsys/partition_manager/Kconfig.template.partition_size"
 
+partition=MCUBOOT_SCRATCH
+partition-size=0x1e000
+source "${ZEPHYR_BASE}/../nrf/subsys/partition_manager/Kconfig.template.partition_size"
 
-# Define used by partition_manager.py to deduce size of partition
-config PM_PARTITION_SIZE_MCUBOOT_SCRATCH
-	hex "Flash space reserved for scratch."
-	default 0x1e000
-	help
-	  Flash space set aside for the scratch area.
+partition=MCUBOOT_STORAGE
+partition-size=0x4000
+source "${ZEPHYR_BASE}/../nrf/subsys/partition_manager/Kconfig.template.partition_size"
 
-# Define used by partition_manager.py to deduce size of partition
-config PM_PARTITION_SIZE_MCUBOOT_STORAGE
-	hex "Flash space reserved for storage."
-	default 0x4000
-	help
-	  Flash space set aside for the storage area.
-
-# Define used by partition_manager.py to deduce size of partition
-config PM_PARTITION_SIZE_MCUBOOT_PAD
-	hex "Flash space reserved for padding area."
-	default 0x200
-	help
-	  Flash space set aside for the padding area.
+partition=MCUBOOT_PAD
+partition-size=0x200
+source "${ZEPHYR_BASE}/../nrf/subsys/partition_manager/Kconfig.template.partition_size"
 
 config BOOT_USE_MBEDTLS
 	bool

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -7,31 +7,11 @@ config MCUBOOT_CMAKELISTS_DIR
 	default "$MCUBOOT_BASE/boot/zephyr/"
 
 
-choice
-	prompt "MCUBoot build strategy"
-	default MCUBOOT_BUILD_STRATEGY_FROM_SOURCE
-
-config MCUBOOT_BUILD_STRATEGY_USE_HEX_FILE
-	# Mandatory option when being built through 'zephyr_add_executable'
-	bool "Use hex file instead of building MCUBoot"
-
-if MCUBOOT_BUILD_STRATEGY_USE_HEX_FILE
-
-config MCUBOOT_HEX_FILE
-	# Mandatory option when being built through 'zephyr_add_executable'
-	string "MCUBoot hex file"
-
-endif # MCUBOOT_USE_HEX_FILE
-
-config MCUBOOT_BUILD_STRATEGY_SKIP_BUILD
-	# Mandatory option when being built through 'zephyr_add_executable'
-	bool "Skip building MCUBoot"
-
-config MCUBOOT_BUILD_STRATEGY_FROM_SOURCE
-	# Mandatory option when being built through 'zephyr_add_executable'
-	bool "Build from source"
-
-endchoice
+# The name of this configuration needs to match the requirements set by the
+# script `partition_manager.py`. See `pm.yml` in the application directory
+# of MCUBoot.
+module=MCUBOOT
+source "${ZEPHYR_BASE}/../nrf/subsys/partition_manager/Kconfig.template.build_strategy"
 
 config MCUBOOT_IMAGE_VERSION
         string "Image version"


### PR DESCRIPTION
Leverage the kconfig template functionality to have cleaner
Kconfig code which is also less error prone.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>