### PR TITLE
[nrf toup] cmake: make update.hex without trailer data

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -17,6 +17,7 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
   set(signed_image_bin ${PROJECT_BINARY_DIR}/signed.bin)
   set(to_sign_bin ${PROJECT_BINARY_DIR}/to_sign.bin)
   set(update_hex ${PROJECT_BINARY_DIR}/update.hex)
+  set(test_update_hex ${PROJECT_BINARY_DIR}/test_update.hex)
   set(update_bin ${PROJECT_BINARY_DIR}/update.bin)
 
   get_property(app_binary_dir GLOBAL PROPERTY PROJECT_BINARY_DIR)
@@ -64,6 +65,10 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
     COMMAND
     ${sign_cmd}
     --pad # This argument is needed for MCUboot to apply the test swap.
+    ${to_sign_hex}
+    ${test_update_hex}
+    COMMAND
+    ${sign_cmd}
     ${to_sign_hex}
     ${update_hex}
     COMMAND


### PR DESCRIPTION
This is needed for serial recovery to work using hex files.
Prior to this the update.hex got TLV data at the end of the
partition, which caused many blank pages to be included,
which made it hard to use in a serial recovery scheme.

Instead, make update.hex without TLV data at the end,
and provide a new file test_update.hex which contains
the TLV data, and can be directly flashed to test the
upgrade procedure.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>