### PR TITLE
Create update candidate for S1 and S0

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -1,6 +1,75 @@
 if(CONFIG_BOOTLOADER_MCUBOOT)
-  # Build a second bootloader image
+  function(sign to_sign_hex output_prefix offset sign_depends signed_hex_out)
+    set(op ${output_prefix})
+    set(signed_hex ${op}_signed.hex)
+    set(${signed_hex_out} ${signed_hex} PARENT_SCOPE)
+    set(to_sign_bin ${op}_to_sign.bin)
+    set(update_bin ${op}_update.bin)
+    set(moved_test_update_hex ${op}_moved_test_update.hex)
+    set(test_update_hex ${op}_test_update.hex)
 
+    add_custom_command(
+      OUTPUT
+      ${update_bin}            # Signed binary of input hex.
+      ${signed_hex}            # Signed hex of input hex.
+      ${test_update_hex}       # Signed hex with IMAGE_MAGIC
+      ${moved_test_update_hex} # Signed hex with IMAGE_MAGIC located at secondary slot
+
+      COMMAND
+      # Create signed hex file from input hex file.
+      # This does not have the IMAGE_MAGIC at the end. So for this hex file
+      # to be applied by mcuboot, the application is required to write the
+      # IMAGE_MAGIC into the image trailer.
+      ${sign_cmd}
+      ${to_sign_hex}
+      ${signed_hex}
+
+      COMMAND
+      # Create binary version of the input hex file, this is done so that we
+      # can create a signed binary file which will be transferred in OTA
+      # updates.
+      ${CMAKE_OBJCOPY}
+      --input-target=ihex
+      --output-target=binary
+      ${to_sign_hex}
+      ${to_sign_bin}
+
+      COMMAND
+      # Sign the binary version of the input hex file.
+      ${sign_cmd}
+      ${to_sign_bin}
+      ${update_bin}
+
+      COMMAND
+      # Create signed hex file from input hex file *with* IMAGE_MAGIC.
+      # As this includes the IMAGE_MAGIC in its image trailer, it will be
+      # swapped in by mcuboot without any invocation from the app. Note,
+      # however, that this this hex file is located in the same address space
+      # as the input hex file, so in order for it to work as a test update,
+      # it needs to be moved.
+      ${sign_cmd}
+      --pad # Adds IMAGE_MAGIC to end of slot.
+      ${to_sign_hex}
+      ${test_update_hex}
+
+      COMMAND
+      # Create version of test update which is located at the secondary slot.
+      # Hence, if a programmer is given this hex file, it will flash it
+      # to the secondary slot, and upon reboot mcuboot will swap in the
+      # contents of the hex file.
+      ${CMAKE_OBJCOPY}
+      --input-target=ihex
+      --output-target=ihex
+      --change-address ${offset}
+      ${test_update_hex}
+      ${moved_test_update_hex}
+
+      DEPENDS
+      ${sign_depends}
+      )
+  endfunction()
+
+  # Build a second bootloader image
   set(MCUBOOT_BASE ${CMAKE_CURRENT_LIST_DIR}/..)
 
   zephyr_add_executable(mcuboot require_build)
@@ -9,17 +78,6 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
     add_subdirectory(${MCUBOOT_BASE}/boot/zephyr ${CMAKE_BINARY_DIR}/mcuboot)
   endif() # ${require_build}
 
-  set(to_sign_hex ${KERNEL_HEX_NAME})
-
-  # TODO: Assert that the bootloader and image use the same key.
-
-  set(signed_image_hex ${PROJECT_BINARY_DIR}/signed.hex)
-  set(signed_image_bin ${PROJECT_BINARY_DIR}/signed.bin)
-  set(to_sign_bin ${PROJECT_BINARY_DIR}/to_sign.bin)
-  set(update_hex ${PROJECT_BINARY_DIR}/update.hex)
-  set(test_update_hex ${PROJECT_BINARY_DIR}/test_update.hex)
-  set(update_bin ${PROJECT_BINARY_DIR}/update.bin)
-
   get_property(app_binary_dir GLOBAL PROPERTY PROJECT_BINARY_DIR)
   set(merged_hex_file
     ${app_binary_dir}/mcuboot_primary_app.hex)
@@ -27,10 +85,11 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
     mcuboot_primary_app_hex$<SEMICOLON>${PROJECT_BINARY_DIR}/mcuboot_primary_app.hex)
   set(sign_merged
     $<TARGET_EXISTS:partition_manager>)
-  set(to_sign_hex
+  set(app_to_sign_hex
     $<IF:${sign_merged},${merged_hex_file},${PROJECT_BINARY_DIR}/${KERNEL_HEX_NAME}>)
-  set(sign_depends
+  set(app_sign_depends
     $<IF:${sign_merged},${merged_hex_file_depends},zephyr_final>)
+
   set(sign_cmd
     ${PYTHON_EXECUTABLE}
     ${MCUBOOT_BASE}/scripts/imgtool.py
@@ -43,49 +102,20 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
     --pad-header
     )
 
-  add_custom_command(
-    OUTPUT
-    ${signed_image_hex}
-    ${update_hex}
-    ${update_bin}
-    COMMAND
-    ${sign_cmd}
-    ${to_sign_hex}
-    ${signed_image_hex}
-    COMMAND
-    ${CMAKE_OBJCOPY}
-    --input-target=ihex
-    --output-target=binary
-    ${to_sign_hex}
-    ${to_sign_bin}
-    COMMAND
-    ${sign_cmd}
-    ${to_sign_bin}
-    ${update_bin}
-    COMMAND
-    ${sign_cmd}
-    --pad # This argument is needed for MCUboot to apply the test swap.
-    ${to_sign_hex}
-    ${test_update_hex}
-    COMMAND
-    ${sign_cmd}
-    ${to_sign_hex}
-    ${update_hex}
-    COMMAND
-    ${CMAKE_OBJCOPY}
-    --input-target=ihex
-    --output-target=ihex
-    --change-address $<TARGET_PROPERTY:partition_manager,PM_MCUBOOT_PRIMARY_SIZE>
-    ${update_hex}
-    ${PROJECT_BINARY_DIR}/moved_update.hex
-    DEPENDS
-    ${sign_depends}
+  set(app_offset $<TARGET_PROPERTY:partition_manager,PM_MCUBOOT_PRIMARY_SIZE>)
+
+  sign(${app_to_sign_hex}     # Hex to sign
+    ${PROJECT_BINARY_DIR}/app # Prefix for generated files
+    ${app_offset}             # Offset
+    ${app_sign_depends}       # Dependencies
+    app_signed_hex            # Generated hex output variable
     )
-  add_custom_target(mcuboot_sign_target DEPENDS ${signed_image_hex})
+
+  add_custom_target(mcuboot_sign_target DEPENDS ${app_signed_hex})
 
   set_property(GLOBAL PROPERTY
     mcuboot_primary_app_PM_HEX_FILE
-    ${signed_image_hex}
+    ${app_signed_hex}
     )
   set_property(GLOBAL PROPERTY
     mcuboot_primary_app_PM_TARGET

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -121,4 +121,56 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
     mcuboot_primary_app_PM_TARGET
     mcuboot_sign_target
     )
+
+  if (CONFIG_MCUBOOT_BUILD_S1_VARIANT)
+    # Secure Boot (B0) is enabled, and we have to build update candidates
+    # for both S1 and S0.
+
+    # We need to override some attributes of the parent slot S0/S1.
+    # Which contains both the S0/S1 image and the padding/header.
+    foreach(parent_slot s0;s1)
+      set(slot ${parent_slot}_image)
+
+      # Fetch the target and hex file for the current slot.
+      # Note that these hex files are already signed by B0.
+      get_property(${slot}_target GLOBAL PROPERTY ${slot}_PM_TARGET)
+      get_property(${slot}_hex GLOBAL PROPERTY ${slot}_PM_HEX_FILE)
+
+      # The gap from S0/S1 partition is calculated by partition manager
+      # and stored in its target.
+      set(slot_offset
+        $<TARGET_PROPERTY:partition_manager,${parent_slot}_TO_SECONDARY>)
+
+      # Depend on both the target for the hex file, and the hex file itself.
+      set(dependencies "${${slot}_target};${${slot}_hex}")
+
+      set(out_path ${PROJECT_BINARY_DIR}/signed_by_mcuboot_and_b0_${slot})
+
+      sign(${${slot}_hex} # Hex file to sign
+        ${out_path}
+        ${slot_offset}
+        "${dependencies}" # Need "..." to make it a list.
+        signed_hex        # Created file variable
+        )
+
+      # We now have to override the S0/S1 partition, so use `parent_slot`
+      # variable, which is "s0" and "s1" respectively. This to get partition
+      # manager to override the implicitly assigned container hex files.
+
+      # Wrapper target for the generated hex file.
+      add_custom_target(signed_${parent_slot}_target DEPENDS ${signed_hex})
+
+      # Override the container hex file.
+      set_property(GLOBAL PROPERTY
+        ${parent_slot}_PM_HEX_FILE
+        ${signed_hex}
+        )
+
+      # Override the container hex file target.
+      set_property(GLOBAL PROPERTY
+        ${parent_slot}_PM_TARGET
+        signed_${parent_slot}_target
+        )
+    endforeach()
+  endif()
 endif()


### PR DESCRIPTION
Sign both S0 and S1 (which is already signed by B0) in order to prepare update candidates for both slots. 