### PR TITLE
[nrf temphack] ci: Skip GitLint compliance check if PR-title has [nrf mergeup]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,6 +51,11 @@ pipeline {
         script {
           lib_Status.set("PENDING", 'MCUBOOT', CI_STATE);
           dir('mcuboot') {
+
+            if (CI_STATE.MCUBOOT.CHANGE_TITLE.toLowerCase().contains('[nrf mergeup]')) {
+              COMPLIANCE_ARGS = "$COMPLIANCE_ARGS --exclude-module Gitlint"
+            }
+
             def BUILD_TYPE = lib_Main.getBuildType(CI_STATE.MCUBOOT)
             if (BUILD_TYPE == "PR") {
               COMMIT_RANGE = "$CI_STATE.MCUBOOT.MERGE_BASE..$CI_STATE.MCUBOOT.REPORT_SHA"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -205,7 +205,7 @@ GEM
       jekyll-seo-tag (~> 2.1)
     minitest (5.11.3)
     multipart-post (2.0.0)
-    nokogiri (1.9.1)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     octokit (4.13.0)
       sawyer (~> 0.8.0, >= 0.5.3)


### PR DESCRIPTION
This CI plan will skip Linting if '[nrf mergeup]' is in the title. 
Also cherry-picked CVE from upstream which seemed urgent. 