### PR TITLE
[nrf noup] cmake: add fw_metadata overlay if SECURE_BOOT

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -73,13 +73,11 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
   set(MCUBOOT_BASE ${CMAKE_CURRENT_LIST_DIR}/..)
 
   if (CONFIG_MCUBOOT_BUILD_S1_VARIANT)
-    # Inject this configuration from parent image to mcuboot.
     set(conf_path "${ZEPHYR_BASE}/../nrf/subsys/bootloader/image/build_s1.conf")
-    string(FIND ${mcuboot_OVERLAY_CONFIG} ${conf_path} out)
-    if (${out} EQUAL -1)
-      set(mcuboot_OVERLAY_CONFIG
-        "${mcuboot_OVERLAY_CONFIG} ${conf_path}"
-        CACHE STRING "" FORCE)
+    add_overlay_config(${conf_path} mcuboot)
+    if (CONFIG_SECURE_BOOT)
+      set(conf_path "${ZEPHYR_BASE}/../nrf/subsys/fw_metadata/fw_metadata.conf")
+      add_overlay_config(${conf_path} mcuboot)
     endif()
   endif()
 


### PR DESCRIPTION
Also leverage new function 'add_overlay_config'.
This function does exactly what was inlined before.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>