### PR TITLE
bootutil: nrf_cc310: Bugfix for CC310 and shared crypto APIs

### DIFF
--- a/boot/bootutil/include/bootutil/sha256.h
+++ b/boot/bootutil/include/bootutil/sha256.h
@@ -33,6 +33,7 @@
 
 #if (defined(MCUBOOT_USE_MBED_TLS) + \
      defined(MCUBOOT_USE_TINYCRYPT) + \
+     defined(MCUBOOT_USE_NRF_EXTERNAL_CRYPTO) + \
      defined(MCUBOOT_USE_CC310)) != 1
     #error "One crypto backend must be defined either CC310, MBED_TLS or TINYCRYPT"
 #endif

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -120,7 +120,7 @@ config BOOT_CC310
 config BOOT_NRF_EXTERNAL_CRYPTO
 	bool "Use Shared Crypto from bootloader"
 	select BOOT_USE_NRF_EXTERNAL_CRYPTO
-	depends on SECURE_BOOT
+	depends on SECURE_BOOT_CRYPTO_CLIENT
 
 endchoice
 endif #BOOT_SIGNATURE_TYPE_ECDSA_P256

--- a/ext/nrf/cc310_glue.h
+++ b/ext/nrf/cc310_glue.h
@@ -31,12 +31,12 @@ void cc310_sha256_update(nrf_cc310_bl_hash_context_sha256_t *ctx,
 
 static inline void nrf_cc310_enable(void)
 {
-    NRF_CRYPTOCELL->ENABLE=1;
+    NRF_CRYPTOCELL_S->ENABLE=1;
 }
 
 static inline void nrf_cc310_disable(void)
 {
-    NRF_CRYPTOCELL->ENABLE=1;
+    NRF_CRYPTOCELL_S->ENABLE=1;
 }
 
 /* Enable and disable cc310 to reduce power consumption */


### PR DESCRIPTION
Fix some dependencies issues with the Kconfig for shared crypto and add
a check in the `sha256` API to allow for `NRF_EXTERNAL_CRYPTO`. Set
`NRF_CRYPTOCELL` to `NRF_CRYPTOCELL_S` since MCUBoot is typically
running in secure-zone.

Fixes NCSDK-3413

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>