### PR TITLE
[DNM] [nrf noup] Remove direct DT_ constants evaluation in CMakeList

### DIFF
--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -107,7 +107,7 @@ if(CONFIG_BOOTLOADER_MCUBOOT)
     sign
     --key ${MCUBOOT_BASE}/${CONFIG_BOOT_SIGNATURE_KEY_FILE}
     --header-size $<TARGET_PROPERTY:partition_manager,PM_MCUBOOT_PAD_SIZE>
-    --align       ${DT_FLASH_WRITE_BLOCK_SIZE}
+    --align       ${CONFIG_DT_FLASH_WRITE_BLOCK_SIZE}
     --version     ${CONFIG_MCUBOOT_IMAGE_VERSION}
     --slot-size   $<TARGET_PROPERTY:partition_manager,PM_MCUBOOT_PRIMARY_SIZE>
     --pad-header

--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -33,4 +33,7 @@ config BOOT_SIGNATURE_KEY_FILE
 	  with the public key information will be written in a format expected by
 	  MCUboot.
 
+config DT_FLASH_WRITE_BLOCK_SIZE
+	def_int $(dt_int_val,DT_FLASH_WRITE_BLOCK_SIZE)
+
 endmenu


### PR DESCRIPTION
It is no longer possible to directly evaluete DT_ within CMakeList,
instead intermediate variable defined within Kconfig needs to be
used.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>