### PR TITLE
[nrf noup] update path to nrf

### DIFF
--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -73,8 +73,6 @@ if(CONFIG_BOOT_USE_NRF_CC310_BL)
 set(NRFXLIB_DIR ${MCUBOOT_DIR}/../nrfxlib)
 assert_exists(NRFXLIB_DIR)
 endif()
-set(NRF_EXTERNAL_CRYPTO_DIR "${MCUBOOT_DIR}/../nrf/subsys/bootloader/bl_crypto")
-assert_exists(NRF_EXTERNAL_CRYPTO_DIR)
 
 zephyr_library_include_directories(
   include

--- a/boot/zephyr/CMakeLists.txt
+++ b/boot/zephyr/CMakeLists.txt
@@ -70,7 +70,7 @@ assert_exists(MBEDTLS_ASN1_DIR)
 set(NRF_DIR "${MCUBOOT_DIR}/ext/nrf")
 
 if(CONFIG_BOOT_USE_NRF_CC310_BL)
-set(NRFXLIB_DIR ${MCUBOOT_DIR}/../nrfxlib)
+set(NRFXLIB_DIR $ENV{ZEPHYR_BASE}/../nrfxlib)
 assert_exists(NRFXLIB_DIR)
 endif()
 


### PR DESCRIPTION
As the mcuboot project has been moved up one dir,
the relative paths to nrf directory must be
updated.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>