### PR TITLE
[nrf noup] lock mcuboot using fprotect before jumping

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -44,6 +44,11 @@ const struct boot_uart_funcs boot_funcs = {
 #include <usb/class/usb_dfu.h>
 #endif
 
+#if USE_PARTITION_MANAGER && CONFIG_FPROTECT
+#include <fprotect.h>
+#include <pm_config.h>
+
+#endif
 #ifdef CONFIG_SOC_FAMILY_NRF
 #include <hal/nrf_power.h>
 
@@ -228,6 +233,27 @@ void main(void)
     wait_for_usb_dfu();
     BOOT_LOG_INF("USB DFU wait time elapsed");
 #endif
+
+#if USE_PARTITION_MANAGER && CONFIG_FPROTECT
+
+#ifdef PM_S1_ADDRESS
+/* MCUBoot is stored in either S0 or S1, protect both */
+#define PROTECT_SIZE (PM_MCUBOOT_PRIMARY_ADDRESS - PM_S0_ADDRESS)
+#define PROTECT_ADDR PM_S0_ADDRESS
+#else
+/* There is only one instance of MCUBoot */
+#define PROTECT_SIZE (PM_MCUBOOT_PRIMARY_ADDRESS - PM_MCUBOOT_ADDRESS)
+#define PROTECT_ADDR PM_MCUBOOT_ADDRESS
+#endif
+
+    rc = fprotect_area(PROTECT_ADDR, PROTECT_SIZE);
+
+    if (rc != 0) {
+        BOOT_LOG_ERR("Protect mcuboot flash failed, cancel startup.");
+        while (1)
+            ;
+    }
+#endif /* USE_PARTITION_MANAGER && CONFIG_FPROTECT */
 
     rc = boot_go(&rsp);
     if (rc != 0) {

--- a/boot/zephyr/pm.yml
+++ b/boot/zephyr/pm.yml
@@ -35,4 +35,4 @@ mcuboot_pad:
   size: CONFIG_PM_PARTITION_SIZE_MCUBOOT_PAD
   placement:
     before: [mcuboot_primary_app]
-    align: {start: DT_FLASH_ERASE_BLOCK_SIZE}
+    align: {start: CONFIG_FPROTECT_BLOCK_SIZE}

--- a/boot/zephyr/prj.conf
+++ b/boot/zephyr/prj.conf
@@ -38,6 +38,7 @@ CONFIG_BOOT_SIGNATURE_KEY_FILE="root-rsa-2048.pem"
 # CONFIG_TINYCRYPT_SHA256 is not set
 
 CONFIG_FLASH=y
+CONFIG_FPROTECT=y
 
 ### Various Zephyr boards enable features that we don't want.
 # CONFIG_BT is not set


### PR DESCRIPTION
This to enable the secure boot property of the system.

Signed-off-by: Håkon Øye Amundsen <haakon.amundsen@nordicsemi.no>