### PR TITLE
[nrf noup] boot: zephyr: Call fw_info_ext_api_provide() before booting

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -30,6 +30,10 @@
 #include "bootutil/bootutil.h"
 #include "flash_map_backend/flash_map_backend.h"
 
+#ifdef CONFIG_FW_INFO
+#include <fw_info.h>
+#endif
+
 #ifdef CONFIG_MCUBOOT_SERIAL
 #include "boot_serial/boot_serial.h"
 #include "serial_adapter/serial_adapter.h"
@@ -106,6 +110,19 @@ static void do_boot(struct boot_rsp *rsp)
     /* Disable the USB to prevent it from firing interrupts */
     usb_disable();
 #endif
+
+#ifdef CONFIG_EXT_API_PROVIDE_EXT_API_REQUIRED
+    bool provided = fw_info_ext_api_provide(fw_info_find((uint32_t)vt), true);
+
+#ifdef PM_S0_ADDRESS
+    /* Only fail if the immutable bootloader is present. */
+    if (!provided) {
+        BOOT_LOG_ERR("Failed to provide EXT_APIs\n");
+        return;
+    }
+#endif
+#endif
+
     __set_MSP(vt->msp);
     ((void (*)(void))vt->reset)();
 }

--- a/boot/zephyr/prj.conf
+++ b/boot/zephyr/prj.conf
@@ -49,3 +49,5 @@ CONFIG_LOG=y
 CONFIG_LOG_IMMEDIATE=y
 ### Ensure Zephyr logging changes don't use more resources
 CONFIG_LOG_DEFAULT_LEVEL=0
+
+CONFIG_EXT_API_PROVIDE_EXT_API_REQUIRED=y


### PR DESCRIPTION
If EXT_API_PROVIDE EXT_API is enabled. This is relevant only when
the immutable bootloader has booted mcuboot.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>

nrf PR: https://github.com/NordicPlayground/fw-nrfconnect-nrf/pull/1886