### PR TITLE
loader: Fixed warning about uninitialized rc variable

### DIFF
--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -1189,7 +1189,7 @@ done:
 static int
 boot_verify_dependencies(struct boot_loader_state *state)
 {
-    int rc;
+    int rc = -1;
     uint8_t slot;
 
     BOOT_CURR_IMG(state) = 0;


### PR DESCRIPTION
Might get past the loop without going in at least once.

Signed-off-by: Erik Johnson <erik.johnson@nimbelink.com>