### PR TITLE
[nrf noup] boot: zephyr: Fixup on fw_info_ext_api_provide()

### DIFF
--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -111,7 +111,7 @@ static void do_boot(struct boot_rsp *rsp)
     usb_disable();
 #endif
 
-#ifdef CONFIG_EXT_API_PROVIDE_EXT_API_REQUIRED
+#if defined(CONFIG_FW_INFO) && !defined(CONFIG_EXT_API_PROVIDE_EXT_API_UNUSED)
     bool provided = fw_info_ext_api_provide(fw_info_find((uint32_t)vt), true);
 
 #ifdef PM_S0_ADDRESS

--- a/boot/zephyr/prj.conf
+++ b/boot/zephyr/prj.conf
@@ -49,5 +49,3 @@ CONFIG_LOG=y
 CONFIG_LOG_IMMEDIATE=y
 ### Ensure Zephyr logging changes don't use more resources
 CONFIG_LOG_DEFAULT_LEVEL=0
-
-CONFIG_EXT_API_PROVIDE_EXT_API_REQUIRED=y


### PR DESCRIPTION
Fixup for commit
"[nrf noup] boot: zephyr: Call fw_info_ext_api_provide() before booting"
Because of changes in nrf repo (optional EXT_APIs).

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>