### PR TITLE
boot: zephyr: Fix pm.yml for devices which are not using fprotect

### DIFF
--- a/boot/zephyr/pm.yml
+++ b/boot/zephyr/pm.yml
@@ -35,4 +35,6 @@ mcuboot_pad:
   size: CONFIG_PM_PARTITION_SIZE_MCUBOOT_PAD
   placement:
     before: [mcuboot_primary_app]
+#ifdef CONFIG_FPROTECT
     align: {start: CONFIG_FPROTECT_BLOCK_SIZE}
+#endif


### PR DESCRIPTION
The `CONFIG_FPROTECT_BLOCK_SIZE` symbol is not resolved when fprotect is
disabled making partition manager fail when trying to compile samples
which disables fprotect in MCUBoot.

Signed-off-by: Sigvart Hovland <sigvart.hovland@nordicsemi.no>