### PR TITLE
[nrf noup] Kconfig: remove mcuboot_storage size entry

### DIFF
--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -22,10 +22,6 @@ partition=MCUBOOT_SCRATCH
 partition-size=0x1e000
 source "${ZEPHYR_BASE}/../nrf/subsys/partition_manager/Kconfig.template.partition_size"
 
-partition=MCUBOOT_STORAGE
-partition-size=0x4000
-source "${ZEPHYR_BASE}/../nrf/subsys/partition_manager/Kconfig.template.partition_size"
-
 partition=MCUBOOT_PAD
 partition-size=0x200
 source "${ZEPHYR_BASE}/../nrf/subsys/partition_manager/Kconfig.template.partition_size"


### PR DESCRIPTION
MCUBoot storage partition was removed a while ago.
This patch removes its orphaned size configuration entry.

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>